### PR TITLE
Enhance navigation to step

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,12 @@ const CircularPicker = ({
       {steps && steps.map((step, index) => (
         <G transform={{ translate: `${step.x + padding}, ${step.y + padding}` }} key={index}>
           <Circle
+            r={strokeWidth}
+            fill="transparent"
+            strokeWidth="12"
+            onPress={() => goToPercent(step.p)}
+          />
+          <Circle
             r={(strokeWidth / 2.5) / 2}
             fill={stepColor}
             strokeWidth="12"


### PR DESCRIPTION
Adding transparent circle around step to ease the navigation, avoiding multiple taps to hit the small step circle